### PR TITLE
adapting to java 11 and MATSim 12.0-Snapshot

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,6 +5,11 @@
 	<artifactId>matsim-gtfs</artifactId>
 	<version>11.1-SNAPSHOT</version>
 
+	<properties>
+		<maven.compiler.source>11</maven.compiler.source>
+		<maven.compiler.target>11</maven.compiler.target>
+	</properties>
+
 	<repositories>
 		<repository>
 			<!-- Geotools is not on Maven central -->
@@ -47,7 +52,7 @@
 		<dependency>
 			<groupId>org.matsim</groupId>
 			<artifactId>matsim</artifactId>
-			<version>11.0</version>
+			<version>12.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>com.conveyal</groupId>

--- a/src/main/java/org/matsim/contrib/gtfs/GTFS2MATSimSchedule.java
+++ b/src/main/java/org/matsim/contrib/gtfs/GTFS2MATSimSchedule.java
@@ -1,0 +1,61 @@
+package org.matsim.contrib.gtfs;
+
+import org.matsim.api.core.v01.Scenario;
+import org.matsim.contrib.gtfs.RunGTFS2MATSim;
+import org.matsim.contrib.gtfs.TransitSchedulePostProcessTools;
+import org.matsim.core.config.ConfigUtils;
+import org.matsim.core.network.io.MatsimNetworkReader;
+import org.matsim.core.network.io.NetworkWriter;
+import org.matsim.core.scenario.ScenarioUtils;
+import org.matsim.core.utils.geometry.CoordinateTransformation;
+import org.matsim.core.utils.geometry.transformations.TransformationFactory;
+import org.matsim.pt.transitSchedule.api.TransitScheduleReader;
+import org.matsim.pt.transitSchedule.api.TransitScheduleWriter;
+import org.matsim.pt.utils.CreatePseudoNetwork;
+import org.matsim.pt.utils.CreateVehiclesForSchedule;
+import org.matsim.vehicles.VehicleWriterV1;
+
+import java.time.LocalDate;
+
+/*
+ * https://github.com/matsim-org/GTFS2MATSim/blob/master/src/main/java/org/matsim/contrib/gtfs/RunGTFS2MATSimExample.java
+ */
+public class GTFS2MATSimSchedule {
+
+    private static final String gtfs_zip_file = "C:/Users/Amit Agarwal/Google Drive/iitr_amit.ce.iitr/projects/data/GTFS/Delhi_PT/GTFS.zip";
+    private static final String matsimFilesDir = "C:/Users/Amit Agarwal/Google Drive/iitr_amit.ce.iitr/projects/data/GTFS/Delhi_PT/matsimFiles/";
+    private static final CoordinateTransformation ct = TransformationFactory.getCoordinateTransformation(TransformationFactory.WGS84, "EPSG:32643");
+    private static final String matsim_network_file = "C:/Users/Amit Agarwal/Google Drive/iitr_amit.ce.iitr/projects/data/Delhi_Trilokpuri/matsimFiles/Delhi_matsim_network_fromPBF_insideDelhi_upto_level6.xml.gz";
+
+    public static void main(String[] args) {
+        String scheduleFile = matsimFilesDir+"/transitSchedule.xml.gz";
+        String networkFile = matsimFilesDir+"/transit_network.xml.gz";
+        String transitVehiclesFile = matsimFilesDir+"/transit_vehicles.xml.gz";
+
+        LocalDate date = LocalDate.parse("2020-03-01");
+        RunGTFS2MATSim.convertGtfs(gtfs_zip_file, scheduleFile, date, ct, false);
+
+        Scenario scenario = ScenarioUtils.createScenario(ConfigUtils.createConfig());
+        new TransitScheduleReader(scenario).readFile(scheduleFile);
+
+        // copy late/early departures to have at complete schedule from ca. 0:00 to ca. 30:00
+        TransitSchedulePostProcessTools.copyLateDeparturesToStartOfDay(scenario.getTransitSchedule(), 24 * 3600, "copied", false);
+        TransitSchedulePostProcessTools.copyEarlyDeparturesToFollowingNight(scenario.getTransitSchedule(), 6 * 3600, "copied");
+
+        //if neccessary, parse in an existing network file here:
+		new MatsimNetworkReader(scenario.getNetwork()).readFile(matsim_network_file);
+
+        //Create a network around the schedule
+        new CreatePseudoNetwork(scenario.getTransitSchedule(),scenario.getNetwork(),"pt_").createNetwork();
+
+        //Create simple transit vehicles
+        new CreateVehiclesForSchedule(scenario.getTransitSchedule(), scenario.getTransitVehicles()).run();
+
+        //Write out network, vehicles and schedule
+        new NetworkWriter(scenario.getNetwork()).write(networkFile);
+        new TransitScheduleWriter(scenario.getTransitSchedule()).writeFile(scheduleFile);
+        new VehicleWriterV1(scenario.getTransitVehicles()).writeFile(transitVehiclesFile);
+
+    }
+
+}

--- a/src/main/java/org/matsim/contrib/gtfs/GtfsConverter.java
+++ b/src/main/java/org/matsim/contrib/gtfs/GtfsConverter.java
@@ -161,13 +161,13 @@ public class GtfsConverter {
 						if (stopTime.arrival_time != Integer.MIN_VALUE) {
 							arrivalOffset = Time.parseTime(String.valueOf(stopTime.arrival_time)) - departureTime;
 						} else {
-							arrivalOffset = Time.UNDEFINED_TIME;
+							arrivalOffset = Double.NEGATIVE_INFINITY;
 						}
 						double departureOffset;
 						if (stopTime.departure_time != Integer.MIN_VALUE) {
 							departureOffset = Time.parseTime(String.valueOf(stopTime.departure_time)) - departureTime;
 						} else {
-							departureOffset = Time.UNDEFINED_TIME;
+							departureOffset = Double.NEGATIVE_INFINITY;
 						}
 						TransitRouteStop routeStop = ts.getFactory().createTransitRouteStop(stop, arrivalOffset, departureOffset);
 						routeStop.setAwaitDepartureTime(true);

--- a/src/main/java/org/matsim/contrib/gtfs/TransitSchedulePostProcessTools.java
+++ b/src/main/java/org/matsim/contrib/gtfs/TransitSchedulePostProcessTools.java
@@ -62,7 +62,7 @@ public class TransitSchedulePostProcessTools {
 				for (Departure dep: route.getDepartures().values()) {
 					double oldDepartureTime = dep.getDepartureTime();
 					// do not copy Departures which arrive before midnight ()
-					double arrivalAtLastStop = dep.getDepartureTime() + route.getStops().get(route.getStops().size() - 1).getArrivalOffset();
+					double arrivalAtLastStop = dep.getDepartureTime() + route.getStops().get(route.getStops().size() - 1).getArrivalOffset().seconds();
 					if (oldDepartureTime > startTimeOfCopying && 
 							(departureExclusionMarker== null || !dep.getId().toString().contains(departureExclusionMarker)) &&
 							(copyDespiteArrivalBeforeMidnight || arrivalAtLastStop >= 24*3600) ) {

--- a/src/test/java/org/matsim/contrib/gtfs/GtfsTest.java
+++ b/src/test/java/org/matsim/contrib/gtfs/GtfsTest.java
@@ -64,8 +64,8 @@ public class GtfsTest  {
 				Assert.assertEquals(tr1.getTransportMode(), tr2.getTransportMode());
 				for(TransitRouteStop trStop: tr1.getStops()){
 					Assert.assertEquals(trStop.isAwaitDepartureTime(), tr2.getStops().get(tr1.getStops().indexOf(trStop)).isAwaitDepartureTime());
-					Assert.assertEquals(trStop.getDepartureOffset(), tr2.getStops().get(tr1.getStops().indexOf(trStop)).getDepartureOffset(), 0.0);
-					Assert.assertEquals(trStop.getArrivalOffset(), tr2.getStops().get(tr1.getStops().indexOf(trStop)).getArrivalOffset(), 0.0);
+					Assert.assertEquals(trStop.getDepartureOffset().seconds(), tr2.getStops().get(tr1.getStops().indexOf(trStop)).getDepartureOffset().seconds(), 0.0);
+					Assert.assertEquals(trStop.getArrivalOffset().seconds(), tr2.getStops().get(tr1.getStops().indexOf(trStop)).getArrivalOffset().seconds(), 0.0);
 				}
 				Assert.assertEquals(tr1.getDepartures().size(), tr2.getDepartures().size());
 			}

--- a/src/test/java/org/matsim/contrib/gtfs/TransitSchedulePostProcessToolsTest.java
+++ b/src/test/java/org/matsim/contrib/gtfs/TransitSchedulePostProcessToolsTest.java
@@ -174,8 +174,8 @@ public class TransitSchedulePostProcessToolsTest {
 
             NetworkRoute networkRoute = RouteUtils.createLinkNetworkRouteImpl(firstStopLinkId, new ArrayList<Id<Link>>(), lastStopLinkId);
             List<TransitRouteStop> stopsRed = new ArrayList<>(2);
-            stopsRed.add(sf.createTransitRouteStop(firstStop, Time.getUndefinedTime(), 0.0));
-            stopsRed.add(sf.createTransitRouteStop(lastStop, 600, Time.getUndefinedTime()));
+            stopsRed.add(sf.createTransitRouteStop(firstStop, Double.NEGATIVE_INFINITY, 0.0));
+            stopsRed.add(sf.createTransitRouteStop(lastStop, 600, Double.NEGATIVE_INFINITY));
             TransitRoute redABRoute = sf.createTransitRoute(Id.create("redFirstToLast", TransitRoute.class), networkRoute, stopsRed, "hoovercraft");
             redABRoute.addDeparture(sf.createDeparture(Id.create("early", Departure.class), 6.0*3600));
             redABRoute.addDeparture(sf.createDeparture(Id.create("midday", Departure.class), 12.0*3600));


### PR DESCRIPTION
- Tests are fine. 
- RunGTFS2MATSimExample seems to generate the PT files as expected.
- [conveyal gtfs-lib](https://github.com/conveyal/gtfs-lib/blob/e7259b6db4fefb8bee06d0806ab7ce627a7b0336/pom.xml#L74) is still at Java 1.8