### PR TITLE
Housekeeping

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
 		<dependency>
 			<groupId>com.conveyal</groupId>
 			<artifactId>jackson2-geojson</artifactId>
-			<version>0.8</version>
+			<version>0.9</version>
 		</dependency>
 
 	</dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,11 @@
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-failsafe-plugin</artifactId>
+				<version>3.5.2</version>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.13.0</version>
 			</plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -9,8 +9,7 @@
 		<matsim.version>2024.0</matsim.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<maven.compiler.source>17</maven.compiler.source>
-		<maven.compiler.release>17</maven.compiler.release>
+		<maven.compiler.release>21</maven.compiler.release>
 		<junit.version>5.10.2</junit.version>
 	</properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,11 @@
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>3.5.2</version>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-failsafe-plugin</artifactId>
 				<version>3.5.2</version>
 			</plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,7 @@
 		<maven.compiler.release>21</maven.compiler.release>
 		<junit.version>5.11.4</junit.version>
 		<log4j.version>2.24.0</log4j.version>
+		<fastutil.version>8.5.11</fastutil.version>
 	</properties>
 
 	<repositories>
@@ -69,6 +70,11 @@
 			<groupId>com.github.conveyal</groupId>
 			<artifactId>gtfs-lib</artifactId>
 			<version>7.1.0</version>
+		</dependency>
+		<dependency>
+			<groupId>it.unimi.dsi</groupId>
+			<artifactId>fastutil-core</artifactId>
+			<version>${fastutil.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter</artifactId>
+			<artifactId>junit-jupiter-api</artifactId>
 			<version>${junit.version}</version>
 			<scope>test</scope>
 		</dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<maven.compiler.release>21</maven.compiler.release>
-		<junit.version>5.10.2</junit.version>
+		<junit.version>5.11.4</junit.version>
 	</properties>
 
 	<repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<version>15.0-SNAPSHOT</version>
 
 	<properties>
-		<matsim.version>2024.0</matsim.version>
+		<matsim.version>2025.0-2025w04</matsim.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<maven.compiler.release>21</maven.compiler.release>

--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,7 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<maven.compiler.release>21</maven.compiler.release>
 		<junit.version>5.11.4</junit.version>
+		<log4j.version>2.24.0</log4j.version>
 	</properties>
 
 	<repositories>
@@ -70,10 +71,9 @@
 			<version>7.1.0</version>
 		</dependency>
 		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-engine</artifactId>
-			<version>${junit.version}</version>
-			<scope>test</scope>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-api</artifactId>
+			<version>${log4j.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.10.1</version>
+				<version>3.13.0</version>
 			</plugin>
 		</plugins>
 


### PR DESCRIPTION
I did some housekeeping to GTFS2MATSim, mostly updating dependencies and switching to Java 21. All tests still work, it even should fix one open issue.

### Updated Dependencies
* Bump matsim from 2024.0 to 2025.0-2025w04
* Bump junit from 5.10.2 to 5.11.4
* Bump jackson2-geojson from 0.8. to 0.9
* Bump maven-compiler-plugin from 3.10.1 to 3.13.0 (closes #30)

### Specified used undeclared dependencies explicitly
* Specify log4j2 explicitly with 2.24.0
* Specify fastutil explicitly with 8.5.11
* Add maven-failsafe-plugin with version 3.5.2
* Add maven-surefire-plugin with version 3.5.2