### PR TITLE
Fix dependency declaration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,12 +88,6 @@
 			<scope>test</scope>
 		</dependency>
 
-		<dependency>
-			<groupId>com.conveyal</groupId>
-			<artifactId>jackson2-geojson</artifactId>
-			<version>0.9</version>
-		</dependency>
-
 	</dependencies>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,12 @@
 			<scope>test</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>org.mapdb</groupId>
+			<artifactId>mapdb</artifactId>
+			<version>1.0.8</version>
+		</dependency>
+
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
Housekeeping, the 2nd: There were still some dependency mis-declarations in the pom which have been fixed with these changes.

```log
$ mvn org.apache.maven.plugins:maven-dependency-plugin:3.8.1:analyze
...
[INFO] --- maven-dependency-plugin:3.8.1:analyze (default-cli) @ matsim-gtfs ---
[WARNING] Used undeclared dependencies found:
[WARNING]    org.mapdb:mapdb:jar:1.0.8:compile
[WARNING] Unused declared dependencies found:
[WARNING]    com.conveyal:jackson2-geojson:jar:0.9:compile
...
```